### PR TITLE
Dev 0.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>piratemod</groupId>
     <artifactId>PirateMod</artifactId> <!--Keep a note of this one: this is the ID used in the "auto add cards" method-->
     <name>The Abyssal</name>
-    <version>0.4.6</version>
+    <version>0.4.8</version>
     <description>Adds The Abyssal as a new playable character.</description>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>piratemod</groupId>
     <artifactId>PirateMod</artifactId> <!--Keep a note of this one: this is the ID used in the "auto add cards" method-->
     <name>The Abyssal</name>
-    <version>0.4.4</version>
+    <version>0.4.5</version>
     <description>Adds The Abyssal as a new playable character.</description>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>piratemod</groupId>
     <artifactId>PirateMod</artifactId> <!--Keep a note of this one: this is the ID used in the "auto add cards" method-->
     <name>The Abyssal</name>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <description>Adds The Abyssal as a new playable character.</description>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>piratemod</groupId>
     <artifactId>PirateMod</artifactId> <!--Keep a note of this one: this is the ID used in the "auto add cards" method-->
     <name>The Abyssal</name>
-    <version>0.4.8</version>
+    <version>0.5.0</version>
     <description>Adds The Abyssal as a new playable character.</description>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>piratemod</groupId>
     <artifactId>PirateMod</artifactId> <!--Keep a note of this one: this is the ID used in the "auto add cards" method-->
     <name>The Abyssal</name>
-    <version>0.4.5</version>
+    <version>0.4.6</version>
     <description>Adds The Abyssal as a new playable character.</description>
 
     <distributionManagement>

--- a/src/main/java/thePirate/actions/DownWithTheShipAction.java
+++ b/src/main/java/thePirate/actions/DownWithTheShipAction.java
@@ -7,6 +7,7 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 
@@ -19,6 +20,7 @@ public class DownWithTheShipAction extends AbstractGameAction {
 
     private DamageInfo info;
     private float startingDuration;
+    public static final String[] TEXT;
 
     public DownWithTheShipAction(AbstractCreature target, DamageInfo info) {
         this.info = info;
@@ -32,6 +34,7 @@ public class DownWithTheShipAction extends AbstractGameAction {
     public void update() {
         AbstractPlayer player = AbstractDungeon.player;
         int count = player.drawPile.size() - 1;
+        String text = TEXT[0];
 
         int i;
         for(i = 0; i < count; ++i) {
@@ -40,7 +43,7 @@ public class DownWithTheShipAction extends AbstractGameAction {
         }
 
         if(player.drawPile.size() > 0){
-            addToTop(new SelectCardsAction(player.drawPile.group, 1, "Select a card to put on top of you draw pile", false, new Predicate<AbstractCard>() {
+            addToTop(new SelectCardsAction(player.drawPile.group, 1, text, false, new Predicate<AbstractCard>() {
                 @Override
                 public boolean test(AbstractCard card) {
                     return true;
@@ -62,5 +65,8 @@ public class DownWithTheShipAction extends AbstractGameAction {
     }
 
 
+    static {
+        TEXT = CardCrawlGame.languagePack.getUIString("thePirate:DownWithTheShipAction").TEXT;
+    }
 
 }

--- a/src/main/java/thePirate/actions/InvisibleRemovePowerAction.java
+++ b/src/main/java/thePirate/actions/InvisibleRemovePowerAction.java
@@ -1,0 +1,61 @@
+package thePirate.actions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.orbs.AbstractOrb;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+import java.util.Iterator;
+
+public class InvisibleRemovePowerAction extends AbstractGameAction{
+    private String powerToRemove;
+    private AbstractPower powerInstance;
+    private static final float DURATION = 0.1F;
+
+    public InvisibleRemovePowerAction(AbstractCreature target, AbstractCreature source, String powerToRemove) {
+        this.setValues(target, source, this.amount);
+        this.actionType = ActionType.DEBUFF;
+        this.duration = 0.1F;
+        this.powerToRemove = powerToRemove;
+    }
+
+    public InvisibleRemovePowerAction(AbstractCreature target, AbstractCreature source, AbstractPower powerInstance) {
+        this.setValues(target, source, this.amount);
+        this.actionType = ActionType.DEBUFF;
+        this.duration = 0.1F;
+        this.powerInstance = powerInstance;
+    }
+
+    public void update() {
+        if (this.duration == 0.1F) {
+            if (this.target.isDeadOrEscaped()) {
+                this.isDone = true;
+                return;
+            }
+
+            AbstractPower removeMe = null;
+            if (this.powerToRemove != null) {
+                removeMe = this.target.getPower(this.powerToRemove);
+            } else if (this.powerInstance != null && this.target.powers.contains(this.powerInstance)) {
+                removeMe = this.powerInstance;
+            }
+
+            if (removeMe != null) {
+                removeMe.onRemove();
+                this.target.powers.remove(removeMe);
+                AbstractDungeon.onModifyPower();
+                Iterator var2 = AbstractDungeon.player.orbs.iterator();
+
+                while(var2.hasNext()) {
+                    AbstractOrb o = (AbstractOrb)var2.next();
+                    o.updateDescription();
+                }
+            } else {
+                this.duration = 0.0F;
+            }
+        }
+
+        this.tickDuration();
+    }
+}

--- a/src/main/java/thePirate/actions/UnstableFormulaAction.java
+++ b/src/main/java/thePirate/actions/UnstableFormulaAction.java
@@ -1,0 +1,42 @@
+package thePirate.actions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import thePirate.powers.InkPower;
+
+public class UnstableFormulaAction extends AbstractGameAction {
+
+
+    public AbstractCreature owner;
+    public AbstractPower power;
+    public int multiplier;
+
+    public UnstableFormulaAction(AbstractCreature owner, AbstractPower power, int multiplier) {
+        this.owner = owner;
+        this.power = power;
+        this.multiplier = multiplier;
+    }
+
+    @Override
+    public void update() {
+
+        boolean flash = false;
+        for(AbstractMonster mo : AbstractDungeon.getCurrRoom().monsters.monsters){
+            AbstractPower power = mo.getPower(InkPower.POWER_ID);
+            if (power != null)
+            if (power != null && power.amount > 0){
+                int newAmount = power.amount * multiplier;
+
+                addToBot(new ApplyPowerAction(mo,owner,new InkPower(mo, owner,newAmount)));
+                flash = true;
+            }
+        }
+        if (flash)
+            power.flash();
+        isDone = true;
+    }
+}

--- a/src/main/java/thePirate/cards/Cannon.java
+++ b/src/main/java/thePirate/cards/Cannon.java
@@ -10,9 +10,6 @@ import thePirate.PirateMod;
 import thePirate.characters.ThePirate;
 import thePirate.powers.RetainCannonballPower;
 import thePirate.relics.AbstractCannonRelic;
-import thePirate.relics.GoldCannon;
-import thePirate.relics.PlatinumCannon;
-import thePirate.relics.SilverCannon;
 
 import static thePirate.PirateMod.makeCardPath;
 
@@ -61,9 +58,6 @@ public class Cannon extends AbstractCannonCard{
     public void triggerOnEndOfTurnForPlayingCard() {
         AbstractPlayer p = AbstractDungeon.player;
         this.addToTop(new ApplyPowerAction(p, p,new RetainCannonballPower(AbstractDungeon.player, 1),1,true));
-        if (p.hasRelic(SilverCannon.ID) || p.hasRelic(GoldCannon.ID) || p.hasRelic(PlatinumCannon.ID)){
-            this.addToTop(new ApplyPowerAction(p, p,new RetainCannonballPower(AbstractDungeon.player, 1),1,true));
-        }
     }
 
     // Actions the card should do.

--- a/src/main/java/thePirate/cards/Cannon.java
+++ b/src/main/java/thePirate/cards/Cannon.java
@@ -33,13 +33,6 @@ public class Cannon extends AbstractCannonCard{
     public static final String IMG = makeCardPath(Cannon.class.getSimpleName() + ".png", TYPE);
     // /TEXT DECLARATION/
 
-    @Override
-    public void triggerOnEndOfPlayerTurn(){
-        this.addToTop(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player, new RetainCannonballPower(AbstractDungeon.player, this.cannonballsRetainCount), this.cannonballsRetainCount));
-        super.triggerOnEndOfPlayerTurn();
-
-    }
-
     public Cannon() {
         this(TARGET);
     }
@@ -57,19 +50,19 @@ public class Cannon extends AbstractCannonCard{
     @Override
     public void triggerOnEndOfTurnForPlayingCard() {
         AbstractPlayer p = AbstractDungeon.player;
-        this.addToTop(new ApplyPowerAction(p, p,new RetainCannonballPower(AbstractDungeon.player, 1),1,true));
+        this.addToTop(new ApplyPowerAction(p, p,new RetainCannonballPower(AbstractDungeon.player, cannonballsRetainCount),cannonballsRetainCount,true));
     }
+
+
 
     // Actions the card should do.
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        PirateMod.logger.info("enter Cannon.use()");
 
         for(AbstractRelic relic : p.relics){
             if(relic instanceof AbstractCannonRelic){
                 AbstractCannonRelic cannonRelic = (AbstractCannonRelic)relic;
                 for (AbstractGameAction action : cannonRelic.onUseCannon(p,m)){
-                    PirateMod.logger.info("adding action " + action.getClass());
                     addToBot(action);
                 }
             }

--- a/src/main/java/thePirate/cards/attacks/GiantBeak.java
+++ b/src/main/java/thePirate/cards/attacks/GiantBeak.java
@@ -1,5 +1,6 @@
 package thePirate.cards.attacks;
 
+import basemod.helpers.TooltipInfo;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
@@ -12,8 +13,11 @@ import thePirate.PirateMod;
 import thePirate.cards.AbstractDynamicCard;
 import thePirate.characters.ThePirate;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
+import static com.megacrit.cardcrawl.core.CardCrawlGame.languagePack;
 import static thePirate.PirateMod.makeCardPath;
 
 public class GiantBeak extends AbstractDynamicCard {
@@ -53,8 +57,16 @@ public class GiantBeak extends AbstractDynamicCard {
     }
 
     @Override
+    public List<TooltipInfo> getCustomTooltips() {
+        String title = rawDescription = languagePack.getCardStrings(ID).EXTENDED_DESCRIPTION[0];
+        String desc = rawDescription = languagePack.getCardStrings(ID).EXTENDED_DESCRIPTION[1];
+        List<TooltipInfo> toolTips = new ArrayList<>();
+        toolTips.add(new TooltipInfo(title, desc));
+        return toolTips;
+    }
+
+    @Override
     public void calculateCardDamage(AbstractMonster mo) {
-        PirateMod.logger.info("enter calculateDamage");
         int realBaseDamage = this.baseDamage;
         int artifactCount = 0;
         int vulnerableCount = 0;

--- a/src/main/java/thePirate/cards/attacks/GiantBeak.java
+++ b/src/main/java/thePirate/cards/attacks/GiantBeak.java
@@ -58,9 +58,9 @@ public class GiantBeak extends AbstractDynamicCard {
 
     @Override
     public List<TooltipInfo> getCustomTooltips() {
-        String title = rawDescription = languagePack.getCardStrings(ID).EXTENDED_DESCRIPTION[0];
-        String desc = rawDescription = languagePack.getCardStrings(ID).EXTENDED_DESCRIPTION[1];
         List<TooltipInfo> toolTips = new ArrayList<>();
+        String title = languagePack.getCardStrings(ID).EXTENDED_DESCRIPTION[0];
+        String desc = languagePack.getCardStrings(ID).EXTENDED_DESCRIPTION[1];
         toolTips.add(new TooltipInfo(title, desc));
         return toolTips;
     }

--- a/src/main/java/thePirate/cards/attacks/GrapeShot.java
+++ b/src/main/java/thePirate/cards/attacks/GrapeShot.java
@@ -9,6 +9,7 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePirate.PirateMod;
 import thePirate.characters.ThePirate;
 
+import static com.megacrit.cardcrawl.core.CardCrawlGame.languagePack;
 import static thePirate.PirateMod.makeCardPath;
 
 public class GrapeShot extends AbstractCannonBallCard {
@@ -50,7 +51,16 @@ public class GrapeShot extends AbstractCannonBallCard {
         storm(p,m);
     }
 
-
+    @Override
+    public void applyPowers() {
+        super.applyPowers();
+        if(AbstractDungeon.actionManager.cardsPlayedThisTurn.size() > 0){
+            rawDescription = languagePack.getCardStrings(ID).EXTENDED_DESCRIPTION[0];
+        }else {
+            rawDescription = languagePack.getCardStrings(ID).DESCRIPTION;
+        }
+        initializeDescription();
+    }
 
     // Upgraded stats.
     @Override

--- a/src/main/java/thePirate/cards/attacks/Sandblast.java
+++ b/src/main/java/thePirate/cards/attacks/Sandblast.java
@@ -3,6 +3,7 @@ package thePirate.cards.attacks;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
@@ -12,10 +13,13 @@ import thePirate.PirateMod;
 import thePirate.cards.AbstractDynamicCard;
 import thePirate.characters.ThePirate;
 import thePirate.patches.actions.CardCounterPatches;
+import thePirate.powers.OnBury;
+
+import java.util.List;
 
 import static thePirate.PirateMod.makeCardPath;
 
-public class Sandblast extends AbstractDynamicCard {
+public class Sandblast extends AbstractDynamicCard implements OnBury {
 
     // STAT DECLARATION
 
@@ -45,12 +49,7 @@ public class Sandblast extends AbstractDynamicCard {
         super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
         baseDamage = DAMAGE;
         magicNumber = baseMagicNumber = MAGIC;
-    }
-
-    @Override
-    public void applyPowers() {
         setCostForTurn(cost - CardCounterPatches.cardsBuriedThisTurn);
-        super.applyPowers();
     }
 
     public void atTurnStart() {
@@ -83,4 +82,16 @@ public class Sandblast extends AbstractDynamicCard {
         }
     }
 
+    @Override
+    public void onBury(AbstractCard card) {
+
+    }
+
+    @Override
+    public void onBuryCards(List<AbstractCard> cards) {
+        setCostForTurn(costForTurn - cards.size());
+        if (costForTurn < 0){
+            costForTurn = 0;
+        }
+    }
 }

--- a/src/main/java/thePirate/cards/skills/Cyclone.java
+++ b/src/main/java/thePirate/cards/skills/Cyclone.java
@@ -2,11 +2,13 @@ package thePirate.cards.skills;
 
 import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePirate.PirateMod;
 import thePirate.cards.AbstractDynamicCard;
 import thePirate.characters.ThePirate;
 
+import static com.megacrit.cardcrawl.core.CardCrawlGame.languagePack;
 import static thePirate.PirateMod.makeCardPath;
 
 public class Cyclone extends AbstractDynamicCard {
@@ -37,14 +39,16 @@ public class Cyclone extends AbstractDynamicCard {
         storm = true;
     }
 
-/*
     @Override
     public void applyPowers() {
         super.applyPowers();
-        rawDescription = languagePack.getCardStrings(ID).DESCRIPTION;
-        this.initializeDescription();
+        if(AbstractDungeon.actionManager.cardsPlayedThisTurn.size() > 0){
+            rawDescription = languagePack.getCardStrings(ID).EXTENDED_DESCRIPTION[0];
+        }else {
+            rawDescription = languagePack.getCardStrings(ID).DESCRIPTION;
+        }
+        initializeDescription();
     }
-*/
 
     // Actions the card should do.
     @Override

--- a/src/main/java/thePirate/cards/skills/GeneticSplice.java
+++ b/src/main/java/thePirate/cards/skills/GeneticSplice.java
@@ -40,6 +40,7 @@ public class GeneticSplice extends AbstractDynamicCard {
         super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = MAGIC;
         block = baseBlock = BLOCK;
+        exhaust = true;
     }
 
 

--- a/src/main/java/thePirate/cards/skills/SwabTheDeck.java
+++ b/src/main/java/thePirate/cards/skills/SwabTheDeck.java
@@ -42,6 +42,21 @@ public class SwabTheDeck extends AbstractDynamicCard {
         this.block = this.baseBlock = BLOCK;
         this.magicNumber = this.baseMagicNumber = EXTRA_BLOCK;
     }
+    @Override
+    public void applyPowers() {
+
+        //put magic number in the block variable to modify with dex
+        int tmpBaseBlock = baseBlock;
+        baseBlock = baseMagicNumber;
+        super.applyPowers();
+        this.isMagicNumberModified = this.isBlockModified;
+        magicNumber = block;
+
+        //recalculate block
+        baseBlock = tmpBaseBlock;
+        super.applyPowers();
+
+    }
 
 
     // Actions the card should do.

--- a/src/main/java/thePirate/powers/InkPower.java
+++ b/src/main/java/thePirate/powers/InkPower.java
@@ -118,7 +118,7 @@ public class InkPower extends AbstractPower implements CloneablePowerInterface, 
 
 
     @Override
-    public void atEndOfRound() {
+    public void atEndOfTurn(boolean isPlayer) {
         if(AbstractDungeon.player.hasPower(VolatileInkPower.POWER_ID) || owner.hasPower(TropomyosinPower.POWER_ID)){
             this.addToBot(new RemoveSpecificPowerAction(this.owner, this.owner, POWER_ID));
         }

--- a/src/main/java/thePirate/powers/InkPower.java
+++ b/src/main/java/thePirate/powers/InkPower.java
@@ -48,6 +48,9 @@ public class InkPower extends AbstractPower implements CloneablePowerInterface, 
         // We load those txtures here.
         this.region128 = new TextureAtlas.AtlasRegion(tex84, 0, 0, 84, 84);
         this.region48 = new TextureAtlas.AtlasRegion(tex32, 0, 0, 32, 32);
+        if (this.amount >= 999) {
+            this.amount = 999;
+        }
 
         updateDescription();
     }
@@ -101,6 +104,13 @@ public class InkPower extends AbstractPower implements CloneablePowerInterface, 
 
     }
 
+    @Override
+    public void stackPower(int stackAmount) {
+        super.stackPower(stackAmount);
+        if (this.amount >= 999) {
+            this.amount = 999;
+        }
+    }
     // Note: If you want to apply an effect when a power is being applied you have 3 options:
     //onInitialApplication is "When THIS power is first applied for the very first time only."
     //onApplyPower is "When the owner applies a power to something else (only used by Sadistic Nature)."

--- a/src/main/java/thePirate/powers/InkPower.java
+++ b/src/main/java/thePirate/powers/InkPower.java
@@ -118,11 +118,7 @@ public class InkPower extends AbstractPower implements CloneablePowerInterface, 
     // Update the description when you apply this power. (i.e. add or remove an "s" in keyword(s))
     @Override
     public void updateDescription() {
-        if (amount == 1) {
-            description = DESCRIPTIONS[0] + amount + DESCRIPTIONS[1];
-        } else if (amount > 1) {
-            description = DESCRIPTIONS[0] + amount + DESCRIPTIONS[2];
-        }
+        description = DESCRIPTIONS[0];
     }
 
     @Override

--- a/src/main/java/thePirate/powers/RetainCannonballPower.java
+++ b/src/main/java/thePirate/powers/RetainCannonballPower.java
@@ -13,6 +13,7 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.PowerStrings;
 import com.megacrit.cardcrawl.powers.AbstractPower;
+import thePirate.actions.InvisibleRemovePowerAction;
 import thePirate.cards.attacks.AbstractCannonBallCard;
 import thePirate.util.TextureLoader;
 
@@ -47,10 +48,17 @@ public class RetainCannonballPower extends AbstractPower implements CloneablePow
 
     public void atEndOfTurn(boolean isPlayer) {
         this.flash();
+        String text = "";
+        if (amount == 1){
+            text = powerStrings.DESCRIPTIONS[0]+ powerStrings.DESCRIPTIONS[1];
+        }else {
+            text = powerStrings.DESCRIPTIONS[0]+ amount + powerStrings.DESCRIPTIONS[2];
+        }
         if (isPlayer && !AbstractDungeon.player.hand.isEmpty() && !AbstractDungeon.player.hasRelic("Runic Pyramid") && !AbstractDungeon.player.hasPower("Equilibrium")) {
-            this.addToBot(new SelectCardsAction(AbstractDungeon.player.hand.group, this.amount, "Choose a Cannonball to retain", false, new Predicate<AbstractCard>() {
+            this.addToBot(new SelectCardsAction(AbstractDungeon.player.hand.group, this.amount, text, false, new Predicate<AbstractCard>() {
                 @Override
                 public boolean test(AbstractCard abstractCard) {
+                    abstractCard.stopGlowing();
                     return abstractCard instanceof AbstractCannonBallCard;
                 }
             }, new Consumer<List<AbstractCard>>() {
@@ -65,18 +73,12 @@ public class RetainCannonballPower extends AbstractPower implements CloneablePow
         }
 
         if (AbstractDungeon.player.hasPower(POWER_ID)) {
-            this.addToBot(new RemoveSpecificPowerAction(this.owner, this.owner, POWER_ID));
+            addToBot(new InvisibleRemovePowerAction(owner, owner, POWER_ID));
         }
 
     }
 
     public void updateDescription() {
-        if (this.amount == 1) {
-            this.description = powerStrings.DESCRIPTIONS[0];
-        } else {
-            this.description = powerStrings.DESCRIPTIONS[1] + this.amount + powerStrings.DESCRIPTIONS[2];
-        }
-
     }
 
     public AbstractPower makeCopy() {
@@ -84,6 +86,6 @@ public class RetainCannonballPower extends AbstractPower implements CloneablePow
     }
 
     static {
-        powerStrings = CardCrawlGame.languagePack.getPowerStrings("RetainCannonballPower");
+        powerStrings = CardCrawlGame.languagePack.getPowerStrings("thePirate:RetainCannonballPower");
     }
 }

--- a/src/main/java/thePirate/powers/TropomyosinPower.java
+++ b/src/main/java/thePirate/powers/TropomyosinPower.java
@@ -30,7 +30,7 @@ public class TropomyosinPower extends AbstractPower implements CloneablePowerInt
         this.amount = 1;
         this.source = AbstractDungeon.player;
 
-        type = PowerType.BUFF;
+        type = PowerType.DEBUFF;
         isTurnBased = false;
         Texture tex84 = TextureLoader.getPowerTexture(this, 84);
         Texture tex32 = TextureLoader.getPowerTexture(this, 32);

--- a/src/main/java/thePirate/powers/UnstableFormulaPower.java
+++ b/src/main/java/thePirate/powers/UnstableFormulaPower.java
@@ -3,14 +3,13 @@ package thePirate.powers;
 import basemod.interfaces.CloneablePowerInterface;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
-import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.PowerStrings;
-import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import thePirate.PirateMod;
+import thePirate.actions.UnstableFormulaAction;
 import thePirate.util.TextureLoader;
 
 public class UnstableFormulaPower extends AbstractPower implements CloneablePowerInterface {
@@ -44,17 +43,7 @@ public class UnstableFormulaPower extends AbstractPower implements CloneablePowe
 
     @Override
     public void atStartOfTurnPostDraw() {
-        boolean flash = false;
-        for(AbstractMonster mo : AbstractDungeon.getCurrRoom().monsters.monsters){
-            AbstractPower power = mo.getPower(InkPower.POWER_ID);
-            if (power != null && power.amount > 0){
-                int newAmount = power.amount * this.amount;
-                addToBot(new ApplyPowerAction(mo,owner,new InkPower(mo, owner,newAmount)));
-                flash = true;
-            }
-        }
-        if (flash)
-            flash();
+        addToBot(new UnstableFormulaAction(owner,this,amount));
     }
 
     // Update the description when you apply this power. (i.e. add or remove an "s" in keyword(s))

--- a/src/main/java/thePirate/variables/StormVariable.java
+++ b/src/main/java/thePirate/variables/StormVariable.java
@@ -28,7 +28,7 @@ public class StormVariable extends DynamicVariable
     @Override
     public int value(AbstractCard card)
     {
-        return AbstractDungeon.actionManager.cardsPlayedThisTurn.size();
+        return AbstractDungeon.actionManager.cardsPlayedThisTurn.size() + 1;
     }
     
     // The baseValue the variable should display.
@@ -36,7 +36,7 @@ public class StormVariable extends DynamicVariable
     @Override
     public int baseValue(AbstractCard card)
     {
-        return 0;
+        return 1;
     }
     
     // If the card has it's damage upgraded, this variable will glow green on the upgrade selection screen as well.

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
@@ -26,7 +26,7 @@
   },
   "thePirate:GeneticSplice": {
     "NAME": "Genetic Splice",
-    "DESCRIPTION": "Remove all thepirate:Ink from target enemy. NL Gain 1 Dexterity for every !M! thepirate:Ink removed. NL Gain !B! Block."
+    "DESCRIPTION": "Remove all thepirate:Ink from enemy. NL Gain 1 Dexterity for every !M! thepirate:Ink removed. NL Gain !B! Block."
   },
   "thePirate:ScoutAhead": {
     "NAME": "Scout Ahead",
@@ -35,7 +35,7 @@
   },
   "thePirate:PinDown": {
     "NAME": "Pin Down",
-    "DESCRIPTION": "Apply !M! Weak to target enemy. NL Shuffle a *Shovel *Blade to your draw pile."
+    "DESCRIPTION": "Apply !M! Weak. NL Shuffle a *Shovel *Blade to your draw pile."
   },
   "thePirate:ShovelBlade": {
     "NAME": "Shovel Blade",
@@ -44,11 +44,11 @@
   },
   "thePirate:EvasiveManeuver": {
     "NAME": "Evasive Maneuver",
-    "DESCRIPTION": "Apply !M! thepirate:Ink to target enemy."
+    "DESCRIPTION": "Apply !M! thepirate:Ink."
   },
   "thePirate:ChainShot": {
     "NAME": "Chain Shot",
-    "DESCRIPTION": "Deal !D! damage. NL Target enemy loses !M! Strength this turn. NL Exhaust."
+    "DESCRIPTION": "Deal !D! damage. NL Enemy loses !M! Strength this turn. NL Exhaust."
   },
   "thePirate:Sandblast": {
     "NAME": "Sandblast",
@@ -60,7 +60,8 @@
   },
   "thePirate:Cyclone": {
     "NAME": "Cyclone",
-    "DESCRIPTION": "Gain !B! Block. NL thepirate:Storm ( !STORM! ). NL Exhaust."
+    "DESCRIPTION": "Gain !B! Block. NL thepirate:Storm. NL Exhaust.",
+    "EXTENDED_DESCRIPTION": ["Gain !B! Block. NL thepirate:Storm ( !STORM! ). NL Exhaust."]
   },
   "thePirate:Headbutt": {
     "NAME": "Headbutt",
@@ -127,7 +128,7 @@
   },
   "thePirate:Kraken": {
     "NAME": "Kraken",
-    "DESCRIPTION": "thepirate:Stun target enemy, then apply !M! thepirate:Ink to ALL enemies. NL thepirate:Predatory. Exhaust."
+    "DESCRIPTION": "thepirate:Stun enemy, then apply !M! thepirate:Ink to ALL enemies. NL thepirate:Predatory. Exhaust."
   },
   "thePirate:ElectricEel": {
     "NAME": "Electric Eel",
@@ -165,7 +166,7 @@
   },
   "thePirate:VolatileInk": {
     "NAME": "Volatile Ink",
-    "DESCRIPTION": "thepirate:Ink is removed from enemies at the end of turn instead."
+    "DESCRIPTION": "Gain thepirate:Volatile_Ink."
   },
   "thePirate:StormSurge": {
     "NAME": "Storm Surge",
@@ -177,15 +178,15 @@
   },
   "thePirate:Subdue": {
     "NAME": "Subdue",
-    "DESCRIPTION": "Deal !D! damage. NL Deals additional damage equal to thepirate:Ink on target."
+    "DESCRIPTION": "Deal !D! damage. NL Deals additional damage equal to thepirate:Ink on enemy."
   },
   "thePirate:ChemicalWarfare": {
     "NAME": "Chemical Warfare",
-    "DESCRIPTION": "Deal !D! damage. NL Target takes 50% more damage from thepirate:Ink."
+    "DESCRIPTION": "Deal !D! damage. NL Enemy takes 50% more damage from thepirate:Ink."
   },
   "thePirate:FlexibleLimb": {
     "NAME": "Flexible Limb",
-    "DESCRIPTION": "Deal !D! damage. NL If target is thepirate:Inked, gain [E] and draw 1 card"
+    "DESCRIPTION": "Deal !D! damage. NL If the enemy has thepirate:Ink, gain [E] and draw 1 card"
   },
   "thePirate:BeachBuddy": {
     "NAME": "Beach Buddy",
@@ -224,12 +225,12 @@
   },
   "thePirate:SorcererAttack": {
     "NAME": "Sorcerer Attack",
-    "DESCRIPTION": "Deal !D! damage. NL Apply thepirate:Corrupt_Artifact to target enemy !M! times. NL Exhaust."
+    "DESCRIPTION": "Deal !D! damage. NL Apply thepirate:Corrupt_Artifact to enemy !M! times. NL Exhaust."
   },
   "thePirate:CausticInk": {
     "NAME": "Caustic Ink",
-    "DESCRIPTION": "Target enemy loses Block, thepirate:Artifacts, and 2 Strength. NL Apply thepirate:Ink equal to Block lost. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "Retain NL Target enemy loses Block, thepirate:Artifacts, and 2 Strength. NL Apply thepirate:Ink equal to Block lost. NL Exhaust."
+    "DESCRIPTION": "Enemy loses Block, thepirate:Artifacts, and 2 Strength. NL Apply thepirate:Ink equal to Block lost. NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "Retain NL Enemy loses Block, thepirate:Artifacts, and 2 Strength. NL Apply thepirate:Ink equal to Block lost. NL Exhaust."
   },
   "thePirate:BeachCrew": {
     "NAME": "Beach Crew",
@@ -241,7 +242,7 @@
   },
   "thePirate:Saboteur": {
     "NAME": "Saboteur",
-    "DESCRIPTION": "Gain !B! Block. NL The next time target enemy would gain Block, instead it doesn't",
+    "DESCRIPTION": "Gain !B! Block. NL The next time enemy would gain Block, instead it doesn't",
     "UPGRADE_DESCRIPTION": "Gain !B! Block. NL The next time ALL enemies would gain Block, instead they don't."
   },
   "thePirate:Ransom": {
@@ -250,11 +251,12 @@
   },
   "thePirate:Tropomyosin": {
     "NAME": "Tropomyosin",
-    "DESCRIPTION": "Target enemy loses !M! Strength and gains !SM! thepirate:Ink. NL This turn, thepirate:Ink is removed at end of turn instead. NL Exhaust."
+    "DESCRIPTION": "Enemy loses !M! Strength and gains !SM! thepirate:Ink. NL Apply thepirate:Volatile_Ink to enemy for 1 turn. NL Exhaust."
   },
   "thePirate:GrapeShot": {
     "NAME": "Grape Shot",
-    "DESCRIPTION": "Deal !D! damage to a random enemy. NL thepirate:Storm ( !STORM! ). NL Exhaust."
+    "DESCRIPTION": "Deal !D! damage to a random enemy. NL thepirate:Storm. NL Exhaust.",
+    "EXTENDED_DESCRIPTION": ["Deal !D! damage to a random enemy. NL thepirate:Storm ( !STORM! ). NL Exhaust."]
   },
   "thePirate:MomentousAttack": {
     "NAME": "Momentous Attack",
@@ -285,8 +287,7 @@
   },
   "thePirate:Menace": {
     "NAME": "Menace",
-    "DESCRIPTION": "Double all debuffs on target enemy. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "Double all debuffs on target enemy."
+    "DESCRIPTION": "Double all debuffs on enemy. NL Exhaust."
   },
   "thePirate:HeadToShore": {
     "NAME": "Head to Shore",

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
@@ -341,7 +341,7 @@
   },
   "thePirate:GiantBeak": {
     "NAME": "Giant Beak",
-    "DESCRIPTION": "Apply !M! Vulnerable and Deal !D! damage.",
+    "DESCRIPTION": "Apply !M! Vulnerable, then deal !D! damage.",
     "EXTENDED_DESCRIPTION": ["Tip", "Giant Beak applies #yVulnerable before dealing damage.  Hover over enemy to see the calculated damage that will be applied after #yVulnerable."]
   },
   "thePirate:Cutlass": {

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
@@ -26,7 +26,7 @@
   },
   "thePirate:GeneticSplice": {
     "NAME": "Genetic Splice",
-    "DESCRIPTION": "Remove all thepirate:Ink from enemy. NL Gain 1 Dexterity for every !M! thepirate:Ink removed. NL Gain !B! Block."
+    "DESCRIPTION": "Remove all thepirate:Ink from enemy. NL Gain 1 Dexterity for every !M! thepirate:Ink removed. NL Gain !B! Block. NL Exhaust."
   },
   "thePirate:ScoutAhead": {
     "NAME": "Scout Ahead",

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
@@ -14,7 +14,7 @@
   },
   "thePirate:DeathKnell": {
     "NAME": "Death Knell",
-    "DESCRIPTION": "Trigger the start of battle and start of turn effects of target Relic (doesn't work with all Relics)."
+    "DESCRIPTION": "Trigger the start of battle and start of turn effects of target Relic (doesn't work with all Relics). NL Exhaust."
   },
   "thePirate:UnstableFormula": {
     "NAME": "Unstable Formula",

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
@@ -132,7 +132,7 @@
   },
   "thePirate:ElectricEel": {
     "NAME": "Electric Eel",
-    "DESCRIPTION": "The first time you draw a card each turn, gain 1 energy. NL thepirate:Predatory."
+    "DESCRIPTION": "The first time you draw a card each turn, gain 1 [E]. NL thepirate:Predatory."
   },
   "thePirate:LowerDefenses": {
     "NAME": "Lower Defenses",
@@ -247,7 +247,7 @@
   },
   "thePirate:Ransom": {
     "NAME": "Ransom",
-    "DESCRIPTION": "thepirate:Bury a card.  Gain energy equal to it's cost"
+    "DESCRIPTION": "thepirate:Bury a card.  Gain energy equal to its cost"
   },
   "thePirate:Tropomyosin": {
     "NAME": "Tropomyosin",

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Card-Strings.json
@@ -341,7 +341,8 @@
   },
   "thePirate:GiantBeak": {
     "NAME": "Giant Beak",
-    "DESCRIPTION": "Apply !M! Vulnerable and Deal !D! damage."
+    "DESCRIPTION": "Apply !M! Vulnerable and Deal !D! damage.",
+    "EXTENDED_DESCRIPTION": ["Tip", "Giant Beak applies #yVulnerable before dealing damage.  Hover over enemy to see the calculated damage that will be applied after #yVulnerable."]
   },
   "thePirate:Cutlass": {
     "NAME": "Cutlass",

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Keyword-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Keyword-Strings.json
@@ -1,5 +1,14 @@
 [
   {
+    "PROPER_NAME": "Volatile Ink",
+    "NAMES": [
+      "volatile ink",
+      "volatile_ink",
+      "volatilenk"
+    ],
+    "DESCRIPTION": "#yInk is removed from enemies at the end of turn instead of during damage (benefits multi-attacks)."
+  },
+  {
     "PROPER_NAME": "Artifacts",
     "NAMES": [
       "artifacts"

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Potion-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Potion-Strings.json
@@ -1,6 +1,6 @@
 {
         "thePirate:IslandPotion": {
-                "NAME": "IslandPotion",
+                "NAME": "Island Potion",
                 "DESCRIPTIONS": ["#yBury, and then #yDig."]
         },
         "thePirate:InkPotion": {

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Power-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Power-Strings.json
@@ -41,7 +41,7 @@
         },
         "thePirate:ElectricEelPower": {
                 "NAME": "Electric Eel",
-                "DESCRIPTIONS": ["The first time you draw a card each turn, draw #b", " card."," cards."]
+                "DESCRIPTIONS": ["The first time you draw a card each turn, gain #b", " energy."," energy."]
         },
         "thePirate:AusterityPower": {
                 "NAME": "Austerity",
@@ -77,7 +77,7 @@
         },
         "thePirate:InkPower": {
                 "NAME": "Ink",
-                "DESCRIPTIONS": ["The next time this enemy would deal damage, prevent damage equal to the ink value, deal that much damage to the enemy, and then remove that much ink. ", "",""]
+                "DESCRIPTIONS": ["The next time this enemy would deal damage, prevent damage equal to the ink value, deal that much damage to the enemy, and then remove that much ink."]
         },
         "thePirate:StartTurnBuryPower": {
                 "NAME": "Beach Crew",

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Power-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Power-Strings.json
@@ -3,6 +3,10 @@
                 "NAME": "Tropomyosin",
                 "DESCRIPTIONS": ["#yInk is removed from enemies at the end of turn instead."]
         },
+        "thePirate:RetainCannonballPower": {
+                "NAME": "Retain Cannonball",
+                "DESCRIPTIONS": ["Choose ", "a Cannonball to Retain.", " Cannonballs to Retain."]
+        },
         "thePirate:UnstableFormulaPower": {
                 "NAME": "Unstable Formula",
                 "DESCRIPTIONS": ["At the start turn, apply #yInk to ALL enemies equal to ", " their current #yInk.", "X their current #yInk."]

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Power-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Power-Strings.json
@@ -17,7 +17,7 @@
         },
         "thePirate:ThiefsAccomplicePower": {
                 "NAME": "Thief's Accomplice",
-                "DESCRIPTIONS": ["The next #b", " time you would lose gold, gain that much gold."," times you would lose gold, gain that much gold."]
+                "DESCRIPTIONS": ["The next #b", " time you would lose #ygold, gain that much #ygold."," times you would lose #ygold, gain that much #ygold."]
         },
         "thePirate:TimeWarpPower": {
                 "NAME": "Time Warp",
@@ -37,11 +37,11 @@
         },
         "thePirate:GainBlockNextTurnPower": {
                 "NAME": "Gain Block Next Turn",
-                "DESCRIPTIONS": ["Next turn, gain #b", " block."," block."]
+                "DESCRIPTIONS": ["Next turn, gain #b", " #yBlock."," #yBlock."]
         },
         "thePirate:ElectricEelPower": {
                 "NAME": "Electric Eel",
-                "DESCRIPTIONS": ["The first time you draw a card each turn, gain #b", " energy."," energy."]
+                "DESCRIPTIONS": ["The first time you draw a card each turn, gain #b", " [E] ."," [E] ."]
         },
         "thePirate:AusterityPower": {
                 "NAME": "Austerity",
@@ -49,7 +49,7 @@
         },
         "thePirate:HardenedBrinePower": {
                 "NAME": "Hardened Brine",
-                "DESCRIPTIONS": ["Whenever you use energy, gain #b", " block for each energy spent."," block for each energy spent."]
+                "DESCRIPTIONS": ["Whenever you use energy, gain #b", " #yBlock for each energy spent."," #yBlock for each energy spent."]
         },
         "thePirate:VolatileInkPower": {
                 "NAME": "Volatile Ink",
@@ -57,11 +57,11 @@
         },
         "thePirate:StormSurgePower": {
                 "NAME": "Storm Surge",
-                "DESCRIPTIONS": ["Whenever you use energy, gain #b", " temporary Strength."," temporary Strength."]
+                "DESCRIPTIONS": ["Whenever you use energy, gain #b", " temporary #yStrength."," temporary #yStrength."]
         },
         "thePirate:TooMuchRumPower": {
                 "NAME": "Too Much Rum",
-                "DESCRIPTIONS": ["Whenever you Bury a card, Exhaust it and gain #b", " block."," block."]
+                "DESCRIPTIONS": ["Whenever you #yBury a card, #yExhaust it and gain #b", " #yBlock."," #yBlock."]
         },
         "thePirate:ChemicalWarfarePower": {
                 "NAME": "Chemical Warfare",
@@ -77,7 +77,7 @@
         },
         "thePirate:InkPower": {
                 "NAME": "Ink",
-                "DESCRIPTIONS": ["The next time this enemy would deal damage, prevent damage equal to the ink value, deal that much damage to the enemy, and then remove that much ink."]
+                "DESCRIPTIONS": ["The next time this enemy would deal damage, prevent damage equal to the #yInk value, deal that much damage to the enemy, and then remove that much #yInk."]
         },
         "thePirate:StartTurnBuryPower": {
                 "NAME": "Beach Crew",
@@ -93,11 +93,11 @@
         },
         "thePirate:SabateurPower": {
                 "NAME": "Sabotaged",
-                "DESCRIPTIONS": ["The next #b", " time this enemy would gain block, instead it doesn't.", " time this enemy would gain block, instead it doesn't."]
+                "DESCRIPTIONS": ["The next #b", " time this enemy would gain #yBlock, instead it doesn't.", " time this enemy would gain #yBlock, instead it doesn't."]
         },
         "thePirate:StartTurnDigPower": {
                 "NAME": "Dig",
-                "DESCRIPTIONS": ["At the start of your next", " turn, Dig.", " #b turns, Dig."]
+                "DESCRIPTIONS": ["At the start of your next", " turn, #yDig.", " #b turns, #yDig."]
         },
         "thePirate:CaptainsQuartersPower": {
                 "NAME": "Captain's Quarters",

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-Relic-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-Relic-Strings.json
@@ -31,7 +31,7 @@
     "NAME": "Navigation Device",
     "FLAVOR": "",
     "DESCRIPTIONS": [
-      "At the start of your second turn each combat, #ythepirate:Dig."
+      "At the start of your 2nd turn, #ythepirate:Dig."
     ]
   },
   "thePirate:WritingReed": {

--- a/src/main/resources/thePirateResources/localization/eng/DefaultMod-UI-Strings.json
+++ b/src/main/resources/thePirateResources/localization/eng/DefaultMod-UI-Strings.json
@@ -1,4 +1,9 @@
 {
+  "thePirate:DownWithTheShipAction": {
+    "TEXT": [
+      "Select a card to put on top of you draw pile and Bury the rest."
+    ]
+  },
   "thePirate:Options": {
     "TEXT": [
       "Skip Tutorials"


### PR DESCRIPTION

Bug: fixed Cards glowing when selecting Cannonball to retain
Bug: fixed Death Knell description to indicate it exhausts
Bug: fixed GiantBeak description breaking when upgraded
Bug: fixed Ink to be capped at 999
Bug: fixed Retain Cannonball text showing up above character at end of turn
Bug: fixed Sandblast not costing 0 with liquid memories
Bug: fixed Swab The Deck to interact correctly with Dexterity
Bug: fixed Tropomyosin Power to be a debuff
Bug: fixed typo in Electric Eel power
Bug: fixed UnstableFormula breaking Volatile Ink power
Bug: fixed upgraded cannon relics causing player to retain two cannonballs

Code: added missing GiantBeak description
Code: moved RetainCannonballPower text into power strings
Code: removed dead code in Cannon

Nerf: updated GeneticSplice to exhaust

Text: added tip on Giant Beak to explain that it applies vulnerable first
Text: fixed energy not rendering properly for Electric Eel
Text: fixed words that needed to be capitalized in power srings
Text: keyworded Volatile Ink and added additional info to indicate that it is used for multi-attacks
Text: removed "target" wording from cad descriptions for consistency with base game
Text: updated Giant Beak description
Text: updated Storm description to indicate the number of times the card will be played
